### PR TITLE
Fix Authentication Problem

### DIFF
--- a/src/FetchApp/API/APIWrapper.php
+++ b/src/FetchApp/API/APIWrapper.php
@@ -78,8 +78,13 @@ class APIWrapper
         }
         curl_close($ch);
         
-        if(trim($ch_data) ):
-        	return simplexml_load_string($ch_data);
+        if (trim($ch_data) ):
+            if ($ch_data == "Couldn't authenticate you") {
+                throw new \Exception($ch_data);
+            } else {
+                return simplexml_load_string($ch_data);
+            }
+	    return simplexml_load_string($ch_data);
         else:
         	return false;
         endif;


### PR DESCRIPTION
If customer isn't authenticated, the response is not XML and fails. This catches that and throws an exception.